### PR TITLE
feat: add pod get/list/watch permissions server SA

### DIFF
--- a/helm/sematic-server/templates/server-role.yaml
+++ b/helm/sematic-server/templates/server-role.yaml
@@ -11,3 +11,6 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs/status"]
   verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]


### PR DESCRIPTION
The Sematic server now needs to [list pods](https://github.com/sematic-ai/sematic/blob/main/sematic/scheduling/kubernetes.py#L340) for a job to get some info it displays when there are k8s errors. This PR adds those permissions to the new helm chart.